### PR TITLE
Add 'use strict' directive to fix error on node 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // @flow
 
 /*::

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "Thinkmill/jest-in-case",
   "author": "James Kyle <me@thejameskyle.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=4"
+  },
   "files": [
     "index.js"
   ],

--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // @flow
 const cases = require('./');
 


### PR DESCRIPTION
`jest-in-case` causes an error on node 4 due to missing `'use strict';` directive:
```
  ● Test suite failed to run

    SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode

      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/ScriptTransformer.js:289:17)
      at Object.<anonymous> (test.js:4:15)
```

This adds the directive and also adds an `engines` field to `package.json` to indicate the minimum supported node version.